### PR TITLE
Add BigQuery logging support

### DIFF
--- a/template.js
+++ b/template.js
@@ -11,6 +11,8 @@ const makeString = require('makeString');
 const parseUrl = require('parseUrl');
 const sendHttpRequest = require('sendHttpRequest');
 const setCookie = require('setCookie');
+const BigQuery = require('BigQuery');
+const getTimestampMillis = require('getTimestampMillis');
 
 /*==============================================================================
 ==============================================================================*/
@@ -24,6 +26,7 @@ if (!isConsentGivenOrNotRequired(data, eventData)) {
 const containerVersion = getContainerVersion();
 const isDebug = containerVersion.debugMode;
 const isLoggingEnabled = determinateIsLoggingEnabled();
+const isBigQueryLoggingEnabled = determinateIsLoggingEnabledForBigQuery();
 const traceId = getRequestHeader('trace-id');
 
 if (data.type === 'page_view') {
@@ -52,6 +55,12 @@ if (data.type === 'page_view') {
     data.clickId || getCookieValues('taboola_cid')[0] || commonCookie.taboola_cid || '';
 
   if (!clickId) {
+    log({
+      Name: 'Taboola',
+      Type: 'Message',
+      EventName: data.eventName,
+      ResponseBody: 'No click ID found. Taboola request skipped.'
+    });
     data.gtmOnSuccess();
     return;
   }
@@ -68,35 +77,32 @@ if (data.type === 'page_view') {
     '&orderid=' +
     enc(data.orderId);
 
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'Taboola',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: data.eventName,
-        RequestMethod: 'POST',
-        RequestUrl: requestUrl
-      })
-    );
-  }
+  log({
+    Name: 'Taboola',
+    Type: 'Request',
+    EventName: data.eventName,
+    RequestMethod: 'POST',
+    RequestUrl: requestUrl,
+    RequestBody: {
+      name: data.eventName,
+      'click-id': clickId,
+      revenue: data.revenue,
+      currency: data.currencyCode,
+      orderid: data.orderId
+    }
+  });
 
   sendHttpRequest(
     requestUrl,
     (statusCode, headers, body) => {
-      if (isLoggingEnabled) {
-        logToConsole(
-          JSON.stringify({
-            Name: 'Taboola',
-            Type: 'Response',
-            TraceId: traceId,
-            EventName: data.eventName,
-            ResponseStatusCode: statusCode,
-            ResponseHeaders: headers,
-            ResponseBody: body
-          })
-        );
-      }
+      log({
+        Name: 'Taboola',
+        Type: 'Response',
+        EventName: data.eventName,
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: headers,
+        ResponseBody: body
+      });
 
       if (statusCode >= 200 && statusCode < 300) {
         data.gtmOnSuccess();
@@ -138,4 +144,69 @@ function determinateIsLoggingEnabled() {
   }
 
   return data.logType === 'always';
+}
+
+function determinateIsLoggingEnabledForBigQuery() {
+  if (data.bigQueryLogType === 'no') return false;
+  return data.bigQueryLogType === 'always';
+}
+
+function log(rawDataToLog) {
+  const logDestinationsHandlers = {};
+  if (isLoggingEnabled) logDestinationsHandlers.console = logConsole;
+  if (isBigQueryLoggingEnabled) logDestinationsHandlers.bigQuery = logToBigQuery;
+
+  rawDataToLog.TraceId = traceId;
+
+  const keyMappings = {
+    bigQuery: {
+      Name: 'tag_name',
+      Type: 'type',
+      TraceId: 'trace_id',
+      EventName: 'event_name',
+      RequestMethod: 'request_method',
+      RequestUrl: 'request_url',
+      RequestBody: 'request_body',
+      ResponseStatusCode: 'response_status_code',
+      ResponseHeaders: 'response_headers',
+      ResponseBody: 'response_body'
+    }
+  };
+
+  for (const logDestination in logDestinationsHandlers) {
+    const handler = logDestinationsHandlers[logDestination];
+    if (!handler) continue;
+
+    const mapping = keyMappings[logDestination];
+    const dataToLog = mapping ? {} : rawDataToLog;
+
+    if (mapping) {
+      for (const key in rawDataToLog) {
+        const mappedKey = mapping[key] || key;
+        dataToLog[mappedKey] = rawDataToLog[key];
+      }
+    }
+
+    handler(dataToLog);
+  }
+}
+
+function logConsole(dataToLog) {
+  logToConsole(JSON.stringify(dataToLog));
+}
+
+function logToBigQuery(dataToLog) {
+  const connectionInfo = {
+    projectId: data.logBigQueryProjectId,
+    datasetId: data.logBigQueryDatasetId,
+    tableId: data.logBigQueryTableId
+  };
+
+  dataToLog.timestamp = getTimestampMillis();
+
+  ['request_body', 'response_headers', 'response_body'].forEach((p) => {
+    dataToLog[p] = JSON.stringify(dataToLog[p]);
+  });
+
+  BigQuery.insert(connectionInfo, [dataToLog], { ignoreUnknownValues: true });
 }

--- a/template.tpl
+++ b/template.tpl
@@ -300,6 +300,8 @@ const makeString = require('makeString');
 const parseUrl = require('parseUrl');
 const sendHttpRequest = require('sendHttpRequest');
 const setCookie = require('setCookie');
+const BigQuery = require('BigQuery');
+const getTimestampMillis = require('getTimestampMillis');
 
 /*==============================================================================
 ==============================================================================*/
@@ -313,6 +315,7 @@ if (!isConsentGivenOrNotRequired(data, eventData)) {
 const containerVersion = getContainerVersion();
 const isDebug = containerVersion.debugMode;
 const isLoggingEnabled = determinateIsLoggingEnabled();
+const isBigQueryLoggingEnabled = determinateIsLoggingEnabledForBigQuery();
 const traceId = getRequestHeader('trace-id');
 
 if (data.type === 'page_view') {
@@ -341,6 +344,12 @@ if (data.type === 'page_view') {
     data.clickId || getCookieValues('taboola_cid')[0] || commonCookie.taboola_cid || '';
 
   if (!clickId) {
+    log({
+      Name: 'Taboola',
+      Type: 'Message',
+      EventName: data.eventName,
+      ResponseBody: 'No click ID found. Taboola request skipped.'
+    });
     data.gtmOnSuccess();
     return;
   }
@@ -357,35 +366,32 @@ if (data.type === 'page_view') {
     '&orderid=' +
     enc(data.orderId);
 
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'Taboola',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: data.eventName,
-        RequestMethod: 'POST',
-        RequestUrl: requestUrl
-      })
-    );
-  }
+  log({
+    Name: 'Taboola',
+    Type: 'Request',
+    EventName: data.eventName,
+    RequestMethod: 'POST',
+    RequestUrl: requestUrl,
+    RequestBody: {
+      name: data.eventName,
+      'click-id': clickId,
+      revenue: data.revenue,
+      currency: data.currencyCode,
+      orderid: data.orderId
+    }
+  });
 
   sendHttpRequest(
     requestUrl,
     (statusCode, headers, body) => {
-      if (isLoggingEnabled) {
-        logToConsole(
-          JSON.stringify({
-            Name: 'Taboola',
-            Type: 'Response',
-            TraceId: traceId,
-            EventName: data.eventName,
-            ResponseStatusCode: statusCode,
-            ResponseHeaders: headers,
-            ResponseBody: body
-          })
-        );
-      }
+      log({
+        Name: 'Taboola',
+        Type: 'Response',
+        EventName: data.eventName,
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: headers,
+        ResponseBody: body
+      });
 
       if (statusCode >= 200 && statusCode < 300) {
         data.gtmOnSuccess();
@@ -427,6 +433,71 @@ function determinateIsLoggingEnabled() {
   }
 
   return data.logType === 'always';
+}
+
+function determinateIsLoggingEnabledForBigQuery() {
+  if (data.bigQueryLogType === 'no') return false;
+  return data.bigQueryLogType === 'always';
+}
+
+function log(rawDataToLog) {
+  const logDestinationsHandlers = {};
+  if (isLoggingEnabled) logDestinationsHandlers.console = logConsole;
+  if (isBigQueryLoggingEnabled) logDestinationsHandlers.bigQuery = logToBigQuery;
+
+  rawDataToLog.TraceId = traceId;
+
+  const keyMappings = {
+    bigQuery: {
+      Name: 'tag_name',
+      Type: 'type',
+      TraceId: 'trace_id',
+      EventName: 'event_name',
+      RequestMethod: 'request_method',
+      RequestUrl: 'request_url',
+      RequestBody: 'request_body',
+      ResponseStatusCode: 'response_status_code',
+      ResponseHeaders: 'response_headers',
+      ResponseBody: 'response_body'
+    }
+  };
+
+  for (const logDestination in logDestinationsHandlers) {
+    const handler = logDestinationsHandlers[logDestination];
+    if (!handler) continue;
+
+    const mapping = keyMappings[logDestination];
+    const dataToLog = mapping ? {} : rawDataToLog;
+
+    if (mapping) {
+      for (const key in rawDataToLog) {
+        const mappedKey = mapping[key] || key;
+        dataToLog[mappedKey] = rawDataToLog[key];
+      }
+    }
+
+    handler(dataToLog);
+  }
+}
+
+function logConsole(dataToLog) {
+  logToConsole(JSON.stringify(dataToLog));
+}
+
+function logToBigQuery(dataToLog) {
+  const connectionInfo = {
+    projectId: data.logBigQueryProjectId,
+    datasetId: data.logBigQueryDatasetId,
+    tableId: data.logBigQueryTableId
+  };
+
+  dataToLog.timestamp = getTimestampMillis();
+
+  ['request_body', 'response_headers', 'response_body'].forEach((p) => {
+    dataToLog[p] = JSON.stringify(dataToLog[p]);
+  });
+
+  BigQuery.insert(connectionInfo, [dataToLog], { ignoreUnknownValues: true });
 }
 
 

--- a/template.tpl
+++ b/template.tpl
@@ -207,6 +207,80 @@ ___TEMPLATE_PARAMETERS___
         "type": "EQUALS"
       }
     ]
+  },
+  {
+    "displayName": "BigQuery Logs Settings",
+    "name": "bigQueryLogsGroup",
+    "groupStyle": "ZIPPY_CLOSED",
+    "type": "GROUP",
+    "enablingConditions": [
+      {
+        "paramName": "type",
+        "paramValue": "page_view",
+        "type": "NOT_EQUALS"
+      }
+    ],
+    "subParams": [
+      {
+        "type": "RADIO",
+        "name": "bigQueryLogType",
+        "radioItems": [
+          {
+            "value": "no",
+            "displayValue": "Do not log to BigQuery"
+          },
+          {
+            "value": "always",
+            "displayValue": "Log to BigQuery"
+          }
+        ],
+        "simpleValueType": true,
+        "defaultValue": "no"
+      },
+      {
+        "type": "GROUP",
+        "name": "logsBigQueryConfigGroup",
+        "groupStyle": "NO_ZIPPY",
+        "subParams": [
+          {
+            "type": "TEXT",
+            "name": "logBigQueryProjectId",
+            "displayName": "BigQuery Project ID",
+            "simpleValueType": true,
+            "help": "Optional. If omitted, it will be retrieved from the environment variable GOOGLE_CLOUD_PROJECT where the server container is running."
+          },
+          {
+            "type": "TEXT",
+            "name": "logBigQueryDatasetId",
+            "displayName": "BigQuery Dataset ID",
+            "simpleValueType": true,
+            "valueValidators": [
+              {
+                "type": "NON_EMPTY"
+              }
+            ]
+          },
+          {
+            "type": "TEXT",
+            "name": "logBigQueryTableId",
+            "displayName": "BigQuery Table ID",
+            "simpleValueType": true,
+            "valueValidators": [
+              {
+                "type": "NON_EMPTY"
+              }
+            ]
+          }
+        ],
+        "enablingConditions": [
+          {
+            "paramName": "bigQueryLogType",
+            "paramValue": "always",
+            "type": "EQUALS"
+          }
+        ]
+      }
+    ]
   }
 ]
 

--- a/template.tpl
+++ b/template.tpl
@@ -770,6 +770,67 @@ ___SERVER_PERMISSIONS___
       "param": []
     },
     "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "access_bigquery",
+        "versionId": "1"
+      },
+      "param": [
+        {
+          "key": "allowedTables",
+          "value": {
+            "type": 2,
+            "listItem": [
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "projectId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "datasetId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "tableId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "operation"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "clientAnnotations": {
+      "isEditedByUser": true
+    },
+    "isRequired": true
   }
 ]
 


### PR DESCRIPTION
## Summary

- Add optional BigQuery logging for conversion events, mirroring the pattern used in [stape-io/facebook-tag](https://github.com/stape-io/facebook-tag)
- Replace inline `logToConsole` calls with a unified `log()` dispatcher that routes to both console and BigQuery
- Add `access_bigquery` permission with wildcard write access

## Details

**New UI group:** "BigQuery Logs Settings" (visible only for conversion mode) with:
- BigQuery Log Type radio (`no` / `always`)
- Project ID (optional, falls back to `GOOGLE_CLOUD_PROJECT`)
- Dataset ID (required)
- Table ID (required)

**Log points:** Request (with query params as JSON object), Response (with status code, headers, body), and "No click ID" diagnostic message.

**Key mapping:** Same as facebook-tag (`Name` → `tag_name`, `Type` → `type`, etc.) so both tags can log to the same BQ table.

Console logging (`logType`) and BigQuery logging (`bigQueryLogType`) operate independently.

## Test plan

- [x] Import template into GTM Server container
- [x] Configure conversion tag with BQ logging enabled
- [x] Fire test conversion and verify BQ row appears with `tag_name = 'Taboola'`
- [x] Verify `request_body` contains JSON object with query params
- [x] Verify `response_status_code` and `response_body` are populated
- [x] Verify console logging still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)